### PR TITLE
Unify startput functions by removing defer.

### DIFF
--- a/autoload/miniyank.vim
+++ b/autoload/miniyank.vim
@@ -26,10 +26,10 @@ endfunction
 function! miniyank#parse_cb() abort
     let parts = split(&clipboard, ',')
     let cbs = ''
-    if index(parts, "unnamed") >= 0
+    if index(parts, 'unnamed') >= 0
         let cbs = cbs.'*'
     endif
-    if index(parts, "unnamedplus") >= 0
+    if index(parts, 'unnamedplus') >= 0
         let cbs = cbs.'+'
     endif
     return cbs
@@ -82,15 +82,15 @@ endfunction
 let s:changedtick = -1
 
 " TODO: put autocommand plz
-function! miniyank#startput(cmd,defer) abort
-    if mode(1) ==# "no"
+function! miniyank#startput(cmd) abort
+    if mode(1) ==# 'no'
         return a:cmd " don't override diffput
     end
     let s:pastelist = miniyank#read()
     let s:cmd = a:cmd
-    let s:visual = index(["v","V","\026"], mode()) >= 0
+    let s:visual = index(['v','V','\026'], mode()) >= 0
     let s:count = string(v:count1)
-    if a:defer
+    if (g:miniyank_default_register != v:register)
         let first = [getreg(v:register,0,1), getregtype(v:register), v:register]
         if !miniyank#fix_clip(s:pastelist, first)
             call miniyank#add_item(s:pastelist, first)
@@ -109,7 +109,7 @@ endfunction
 
 function! miniyank#do_putnext() abort
     if s:pastelist == []
-        echoerr "miniyank: no more items!"
+        echoerr 'miniyank: no more items!'
         return
     endif
     call miniyank#putreg(remove(s:pastelist,0),s:cmd)

--- a/plugin/miniyank.vim
+++ b/plugin/miniyank.vim
@@ -21,10 +21,8 @@ endif
 augroup MiniYank
     au! TextYankPost * call miniyank#on_yank(copy(v:event))
     au VimEnter * let g:miniyank_default_register = v:register
-          \| noremap <Plug>(bare_p) p
-          \| noremap <Plug>(bare_P) P
-          \| execute 'noremap "' . v:register . 'p <Plug>(bare_p)'
-          \| execute 'noremap "' . v:register . 'P <Plug>(bare_P)'
+          \| execute 'noremap "' . v:register . 'p p'
+          \| execute 'noremap "' . v:register . 'P P'
 augroup END
 
 noremap <silent> <expr> <Plug>(miniyank-startput) miniyank#startput("p")

--- a/plugin/miniyank.vim
+++ b/plugin/miniyank.vim
@@ -2,30 +2,29 @@ if !exists('##TextYankPost')
     finish
 endif
 
-if !has_key(g:,"miniyank_filename")
+if !has_key(g:,'miniyank_filename')
     if exists('$XDG_RUNTIME_DIR')
-        let g:miniyank_filename = $XDG_RUNTIME_DIR."/miniyank.mpack"
+        let g:miniyank_filename = $XDG_RUNTIME_DIR.'/miniyank.mpack'
     else
-        let g:miniyank_filename = "/tmp/".$USER."_miniyank.mpack"
+        let g:miniyank_filename = '/tmp/'.$USER.'_miniyank.mpack'
     endif
 endif
 
-if !has_key(g:,"miniyank_maxitems")
+if !has_key(g:,'miniyank_maxitems')
     let g:miniyank_maxitems = 10
 endif
 
-if !has_key(g:,"miniyank_delete_maxlines")
+if !has_key(g:,'miniyank_delete_maxlines')
     let g:miniyank_delete_maxlines = 1000
 endif
 
 augroup MiniYank
     au! TextYankPost * call miniyank#on_yank(copy(v:event))
+    au VimEnter * let g:miniyank_default_register = v:register
 augroup END
 
-noremap <silent> <expr> <Plug>(miniyank-startput) miniyank#startput("p",0)
-noremap <silent> <expr> <Plug>(miniyank-startPut) miniyank#startput("P",0)
-noremap <silent> <expr> <Plug>(miniyank-autoput) miniyank#startput("p",1)
-noremap <silent> <expr> <Plug>(miniyank-autoPut) miniyank#startput("P",1)
+noremap <silent> <expr> <Plug>(miniyank-startput) miniyank#startput("p")
+noremap <silent> <expr> <Plug>(miniyank-startPut) miniyank#startput("P")
 noremap <silent> <Plug>(miniyank-cycle) :<c-u>call miniyank#cycle()<cr>
 
 noremap <silent> <Plug>(miniyank-tochar) :<c-u>call miniyank#force_motion('v')<cr>

--- a/plugin/miniyank.vim
+++ b/plugin/miniyank.vim
@@ -21,6 +21,10 @@ endif
 augroup MiniYank
     au! TextYankPost * call miniyank#on_yank(copy(v:event))
     au VimEnter * let g:miniyank_default_register = v:register
+          \| noremap <Plug>(bare_p) p
+          \| noremap <Plug>(bare_P) P
+          \| execute 'noremap "' . v:register . 'p <Plug>(bare_p)'
+          \| execute 'noremap "' . v:register . 'P <Plug>(bare_P)'
 augroup END
 
 noremap <silent> <expr> <Plug>(miniyank-startput) miniyank#startput("p")


### PR DESCRIPTION
Instead of checking for `defer` argument, check if a register was used.