### PR TITLE
Initialize s:pos in sourcing

### DIFF
--- a/autoload/miniyank.vim
+++ b/autoload/miniyank.vim
@@ -103,6 +103,7 @@ function! miniyank#fix_clip(list, pasted) abort
 endfunction
 
 let s:changedtick = -1
+let s:pos = 0
 
 " TODO: put autocommand plz
 function! miniyank#startput(cmd,defer) abort


### PR DESCRIPTION
When you calls `:Denite miniyank` and do the action `put` before any `<Plug>(miniyank-*)` has not been called, you see this bug below.

<details><summary>bug report</summary>

```
[denite] Traceback (most recent call last):
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/rplugin.py", line 63, in do_map
[denite]     return do_map(ui, args[1], args[2])
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/map.py", line 20, in do_map
[denite]     return MAPPINGS[name](denite, params)
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/map.py", line 65, in _do_action
[denite]     return denite.do_action(name, is_manual=True)
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/ui/default.py", line 86, in do_action
[denite]     self._denite.do_action(self._context, action_name, candidates)
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/parent.py", line 63, in do_action
[denite]     return self._get('do_action', [context, action_name, targets])
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/parent.py", line 84, in _get
[denite]     return self._put(name, args)
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/parent.py", line 80, in _put
[denite]     return self._child.main(name, args, queue_id=None)  # type: ignore
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/child.py", line 83, in main
[denite]     ret = self.do_action(args[0], args[1], args[2])
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/Shougo/denite.nvim/rplugin/python3/denite/child.py", line 260, in do_action
[denite]     if action['func']
[denite]   File "/Users/delphinus/.cache/dein/repos/github.com/bfredl/nvim-miniyank/rplugin/python3/denite/kind/miniyank.py", line 14, in action_put
[denite]     data = self.vim.call("miniyank#drop", data,  'p')
[denite]   File "/Users/delphinus/Library/Python/3.7/lib/python/site-packages/pynvim/api/nvim.py", line 299, in call
[denite]     return self.request('nvim_call_function', name, args, **kwargs)
[denite]   File "/Users/delphinus/Library/Python/3.7/lib/python/site-packages/pynvim/api/nvim.py", line 182, in request
[denite]     res = self._session.request(name, *args, **kwargs)
[denite]   File "/Users/delphinus/Library/Python/3.7/lib/python/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request
[denite]     raise self.error_wrapper(err)
[denite] pynvim.api.nvim.NvimError: b'Vim(call):E121: Undefined variable: s:pos'
[denite] Please execute :messages command.
```
</details>

This patch fixes this.